### PR TITLE
Use match_selector for filtering and expand_variables for vars

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -65,17 +65,31 @@ class IncludeAutoComplete(sublime_plugin.EventListener):
         return completions
 
     def on_query_completions(self, view, prefix, locations):
+        # If we have more than one location, forget about it.
         if len(locations) != 1:
             return None
+
+        # If we're not in an include statement, forget about it.
         if not view.match_selector(locations[0],
                                    "meta.preprocessor.include & "
                                    "(string.quoted.other | "
                                    "string.quoted.double)"):
             return None
+
+        # Get the include directories of the project.
         incl_locs = self.get_include_locations(view)
+
+        # Get the subdir.
+        scope = view.extract_scope(locations[0])
+        firstline = view.split_by_newlines(scope)[0]
+        subdir = view.substr(firstline)
+        subdir = subdir.strip('"<>')
+        subdir = subdir[:-len(prefix)]
+
+        # Present the completions.
         completions = []
         for location in incl_locs:
-            completions += self.get_include_completions(location[0], "", location[1])
+            completions += self.get_include_completions(location[0], subdir, location[1])
         if len(completions) > 0:
             return (completions,
                     sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)


### PR DESCRIPTION
Lovely plugin, thanks!

I made a few minor modifications by using the sublime API in a bunch of places. Notably:

View.match_selector is used to filter the use-case for the completions. expand_variables is used to allow snippet-like variables like `${project_path}/include`.

So, I now have an entry `path: "${project_path}/include"` and all is well in the world.
View.match_selector is used so that we re-use the power of the sublime syntax def already present in the file. We don't have to reinvent our own regexes.

Finally, more file extensions are searched for (hh, hxx, hpp, ipp, inc, inl).